### PR TITLE
Specify the CL-SDL2 dependency in the ASDF file

### DIFF
--- a/console.asd
+++ b/console.asd
@@ -1,8 +1,9 @@
-(asdf:defsystem #:console
-  :components (
-               (:file "cpu")
-               (:file "console"
-		             :depends-on ("cpu" "cartridge" "ppu" "controller"))
+(in-package #:asdf-user)
+
+(defsystem #:console
+  :depends-on (#:sdl2)
+  :components ((:file "cpu")
+               (:file "console" :depends-on ("cpu" "cartridge" "ppu" "controller"))
                (:file "mmu")
                (:file "ppu")
                (:file "controller")

--- a/console.lisp
+++ b/console.lisp
@@ -1,8 +1,3 @@
-(in-package :cl-user)
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (ql:quickload "sdl2"))
-
 (defpackage #:NES-console
   (:nicknames #:nes)
   (:use :cl :cl-user :6502-cpu :NES-cartridge :NES-ppu :NES-controller)


### PR DESCRIPTION
a minor cleanup. It haven't been able to test it successfully as creating a texture fails in my machine (I'll debug the error later), but I've verified it compiles