### PR TITLE
Get button keycodes from *KEYMAP*

### DIFF
--- a/console.lisp
+++ b/console.lisp
@@ -26,16 +26,24 @@
   (declare (nes n))
   (setf (nes-cart n) (NES-cartridge:load-cartridge rom-name)))
 
-(defun get-buttons()
+(defvar *keymap*
+  '((:a      . :scancode-left)
+    (:b      . :scancode-down)
+    (:select . :scancode-grave)
+    (:start  . :scancode-tab)
+    (:up     . :scancode-w)
+    (:down   . :scancode-s)
+    (:left   . :scancode-a)
+    (:right  . :scancode-d))
+  "The mapping of the controller #1 buttons to SDL keycodes. Caveat Emptor, the
+  button-names are for reference, the mapping is determined by the Order.")
+
+(defun get-buttons ()
   (let ((buttons (make-array 8 :element-type '(unsigned-byte 8) :initial-element 0)))
-    (setf (aref buttons 0) (if (sdl2:keyboard-state-p :scancode-left) 1 0))
-    (setf (aref buttons 1) (if (sdl2:keyboard-state-p :scancode-down) 1 0))
-    (setf (aref buttons 2) (if (sdl2:keyboard-state-p :scancode-grave) 1 0))
-    (setf (aref buttons 3) (if (sdl2:keyboard-state-p :scancode-tab) 1 0))
-    (setf (aref buttons 4) (if (sdl2:keyboard-state-p :scancode-w) 1 0))
-    (setf (aref buttons 5) (if (sdl2:keyboard-state-p :scancode-s) 1 0))
-    (setf (aref buttons 6) (if (sdl2:keyboard-state-p :scancode-a) 1 0))
-    (setf (aref buttons 7) (if (sdl2:keyboard-state-p :scancode-d) 1 0))
+    (loop :for index :from 0
+          :for (button-name . button-key) :in *keymap*
+          :do
+             (setf (aref buttons index) (if (sdl2:keyboard-state-p button-key) 1 0))) 
     buttons))
 
 (defun console-on (n)


### PR DESCRIPTION
This allows the user to re-map the controller buttons. For example
```lisp
(defparameter *keymap*
  '((:a      . :scancode-z)
    (:b      . :scancode-x)
    (:select . :scancode-lshift)
    (:start  . :scancode-return)
    (:up     . :scancode-up)
    (:down   . :scancode-down)
    (:left   . :scancode-left)
    (:right  . :scancode-right)))
```

Although no mechanism is provided for the to do so other than `(setf *keymap* ...)`